### PR TITLE
Resolve issues with release

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,6 +1,8 @@
 name: Test gha-secret-manager
 on:
-  - push
+  push:
+    branches-ignore:
+      - 'release/*'
 
 jobs:
   secret_manager:
@@ -9,7 +11,7 @@ jobs:
     steps:
       - name: Test gha-secret-manager
         id: secrets
-        uses: dmsi-io/gha-secret-manager@feature/KNOX-242
+        uses: dmsi-io/gha-secret-manager@main
         with:
           GCP_SA_KEY: ${{ secrets.GCP_SECRET_MANAGER_KEY }}
           secrets: KEY

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,8 +48,7 @@ jobs:
         # Equivalent commit hash to tag v7.5.0
         uses: EndBug/add-and-commit@8c12ff729a98cfbcd3fe38b49f55eceb98a5ec02
         with:
-          author_email: ${{ secrets.GHA_ACCESS_EMAIL }}
-          default_author: ${{ secrets.GHA_ACCESS_USER }}
+          default_author: github_actions
 
       - name: Create and Push Git Tag
         run: |


### PR DESCRIPTION
Upon releasing `v1` caught a small snag in the `release.yaml` action, resolving that here. This won't need to be re-released at this time.