### PR TITLE
[HOU-166]: Resolve checkout permission issue

### DIFF
--- a/secret_manager.sh
+++ b/secret_manager.sh
@@ -76,6 +76,8 @@ function get_tag_parent() {
     else 
         echo "false"
     fi
+
+    rm -rf ${GITHUB_REPOSITORY##*/}
 }
 
 function get_ref() {

--- a/secret_manager.sh
+++ b/secret_manager.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+TMP_DIR="temp_secret"
+
 function main() {
     gcloud_auth
 
@@ -67,8 +69,8 @@ function get_tag_parent() {
         git config --global url."https://$INPUT_GHA_ACCESS_USER:$INPUT_GHA_ACCESS_TOKEN@github.com".insteadOf "https://github.com"
     fi
 
-    mkdir temp_secret
-    cd temp_secret
+    mkdir "$TMP_DIR"
+    cd "$TMP_DIR"
 
     git clone "$GIT_REPO_URL"
 
@@ -93,9 +95,7 @@ function get_ref() {
 
 function cleanup() {
     echo "Cleaning up..."
-    ls -al
-    rm -rf temp_secret
-    ls -al
+    rm -rf "$TMP_DIR"
 }
 
 main "$@"; exit

--- a/secret_manager.sh
+++ b/secret_manager.sh
@@ -72,12 +72,14 @@ function get_tag_parent() {
     git fetch origin "refs/tags/$TAG"
 
     if [[ $(git branch -r --contains $(git rev-list -n 1 tags/$TAG) | egrep "origin/(main|release/*)") ]]; then
+        rm -rf ${GITHUB_REPOSITORY##*/}
+        ls -al
         echo "true"
     else 
+        rm -rf ${GITHUB_REPOSITORY##*/}
+        ls -al
         echo "false"
     fi
-
-    rm -rf ${GITHUB_REPOSITORY##*/}
 }
 
 function get_ref() {

--- a/secret_manager.sh
+++ b/secret_manager.sh
@@ -4,6 +4,8 @@ function main() {
     gcloud_auth
 
     get_secrets
+
+    cleanup
 }
 
 function gcloud_auth() {
@@ -65,6 +67,9 @@ function get_tag_parent() {
         git config --global url."https://$INPUT_GHA_ACCESS_USER:$INPUT_GHA_ACCESS_TOKEN@github.com".insteadOf "https://github.com"
     fi
 
+    mkdir temp_secret
+    cd temp_secret
+
     git clone "$GIT_REPO_URL"
 
     cd ${GITHUB_REPOSITORY##*/}
@@ -72,12 +77,8 @@ function get_tag_parent() {
     git fetch origin "refs/tags/$TAG"
 
     if [[ $(git branch -r --contains $(git rev-list -n 1 tags/$TAG) | egrep "origin/(main|release/*)") ]]; then
-        rm -rf ${GITHUB_REPOSITORY##*/}
-        ls -al
         echo "true"
     else 
-        rm -rf ${GITHUB_REPOSITORY##*/}
-        ls -al
         echo "false"
     fi
 }
@@ -88,6 +89,13 @@ function get_ref() {
     else
         echo "$GITHUB_REF_NAME"
     fi
+}
+
+function cleanup() {
+    echo "Cleaning up..."
+    ls -al
+    rm -rf temp_secret
+    ls -al
 }
 
 main "$@"; exit


### PR DESCRIPTION
## 📑 Description
It was found during testing with this action on tags that it would cause an overlap issue with `actions/checkout` as seen [here](https://github.com/dmsi-io/door-config-api/runs/5293208069?check_suite_focus=true). 

This issue is caused by this action clone the acting repo and running some git commands around tags. Because it cloned the repo within the Docker image it caused an overlap with naming of directories so `actions/checkout` would attempt to remove the directory to no avail. 

Having this action instead clone the repo to a temp directory within the  Docker image and deleting it afterwards resolves this issue as seen [here](https://github.com/dmsi-io/door-config-api/runs/5293887484?check_suite_focus=true)